### PR TITLE
The test runner fixes the exercise's test script "load" command

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -66,6 +66,7 @@ run_tests() {
     # Run tests and pipe output to results.out file.
 
     local slug="$1"
+    local test_file=${slug//-/_}_test.sh
     local solution_dir="$2"
     local output_file="$3"
 
@@ -73,9 +74,11 @@ run_tests() {
 
     cd "$solution_dir"
 
+    sed -i 's/load bats-extra.bash/load bats-extra/' "$test_file"
+
     echo "Test output:"
 
-    bats --tap "${slug//-/_}_test.sh" 2>&1 | tee "$output_file" || true
+    bats --tap "$test_file" 2>&1 | tee "$output_file" || true
 
     echo "Test run ended. Output saved in $output_file"
 


### PR DESCRIPTION
Angelika pointed me to the /maintaining/submissions page where she saw
```
exceptioned

STDOUT:
------
Running exercise tests for Bash
Test slug: hello-world
Solution directory: /mnt/exercism-iteration
Output directory: /mnt/exercism-iteration
Running tests.
Test output:
1..1
bats: /mnt/exercism-iteration/bats-extra.bash.bash does not exist
Test run ended. Output saved in /mnt/exercism-iteration/results.out
Producing JSON report.
Tried to run 1 tests according to TAP plan.
Failed to parse output.
This probably means there was an error running the tests.
Wrote error report to /mnt/exercism-iteration/results.json
```
This indicates the problem line is
```
bats: /mnt/exercism-iteration/bats-extra.bash.bash does not exist
```
which means the line in the exercise's test file
```
load bats-extra.bash
```
should be replaced with
```
load bats-extra
```

Rather than alter all the bash track test files (which work OK on my laptop), I'll update the test runner with a sed command to do the replacement.