### PR TITLE
typo on line 1 is breaking test runner

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,4 +1,4 @@
-jq #!/usr/bin/env bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2164,SC2103
 
 # Arguments:


### PR DESCRIPTION
A stray "jq" make it into the file _before_ the shebang.