### PR TITLE
Add bash and bats versions to test runner results.json file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,12 @@ FROM ubuntu:20.04
 # Test runner needs jq.
 # Other commands to add to environment, might be used by students
 #   - bc
-#   - awk
-#   - sed
+#   - GNU awk (Ubuntu 20.04 ships with mawk)
+# Tools commonly used by students that will already be installed include:
+#   - sed, tr, ...
 
 RUN apt-get update && \
-    apt-get install -y git jq bc gawk sed && \
+    apt-get install -y git jq bc gawk && \
     git clone https://github.com/bats-core/bats-core && \
     cd bats-core && \
     git checkout v1.5.0 && \
@@ -18,7 +19,7 @@ RUN apt-get update && \
     apt-get remove -y git && \
     apt-get purge --auto-remove -y && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* ./bats-core
 
 COPY . /opt/test-runner
 WORKDIR /opt/test-runner

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -203,10 +203,24 @@ print_report() {
     local tests=("$@")
     jq  --null-input \
         --argjson version "$INTERFACE_VERSION" \
+        --argjson tools "$(tool_versions)" \
         --arg status "$status" \
         --jsonargs \
-        '{version: $version, status: $status, tests: $ARGS.positional}' \
+        '{
+            version: $version,
+            status: $status,
+            "test-environment": $tools,
+            tests: $ARGS.positional
+        }' \
         "${tests[@]}"
+}
+
+tool_versions() {
+    # print versions of tools in the test environment
+    jq  --null-input \
+        --arg bash "$BASH_VERSION" \
+        --arg bats "$(bats --version)" \
+        '$ARGS.named'
 }
 
 print_failed_test() {

--- a/tests/data/first_fails/expected_results.json
+++ b/tests/data/first_fails/expected_results.json
@@ -1,6 +1,10 @@
 {
   "version": 2,
   "status": "fail",
+  "test-environment": {
+    "bash": "5.0.17(1)-release",
+    "bats": "Bats 1.5.0"
+  },
   "tests": [
     {
       "name": "say one",

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -24,7 +24,7 @@ actual_matches_expected() {
     run "$RUN_SCRIPT" "$TEST" "$TEST_DIR" "$TEST_DIR"
 
     [[ "$status" -eq 0 ]]
-    actual_matches_expected "$TEST_DIR"/{,expected_}results.json
+    actual_matches_expected "$TEST_DIR/results.json" "$TEST_DIR/expected_results.json"
 }
 
 @test "three passing tests" {
@@ -33,7 +33,7 @@ actual_matches_expected() {
     run "$RUN_SCRIPT" "$TEST" "$TEST_DIR" "$TEST_DIR"
 
     [[ "$status" -eq 0 ]]
-    actual_matches_expected "$TEST_DIR"/{,expected_}results.json
+    actual_matches_expected "$TEST_DIR/results.json" "$TEST_DIR/expected_results.json"
 }
 
 @test "first test fails" {
@@ -42,7 +42,7 @@ actual_matches_expected() {
     run "$RUN_SCRIPT" "$TEST" "$TEST_DIR" "$TEST_DIR"
 
     [[ "$status" -eq 0 ]]
-    actual_matches_expected "$TEST_DIR"/{,expected_}results.json
+    actual_matches_expected "$TEST_DIR/results.json" "$TEST_DIR/expected_results.json"
 }
 
 @test "middle test fails" {
@@ -51,7 +51,7 @@ actual_matches_expected() {
     run "$RUN_SCRIPT" "$TEST" "$TEST_DIR" "$TEST_DIR"
 
     [[ "$status" -eq 0 ]]
-    actual_matches_expected "$TEST_DIR"/{,expected_}results.json
+    actual_matches_expected "$TEST_DIR/results.json" "$TEST_DIR/expected_results.json"
 }
 
 @test "last test fails" {
@@ -60,7 +60,7 @@ actual_matches_expected() {
     run "$RUN_SCRIPT" "$TEST" "$TEST_DIR" "$TEST_DIR"
 
     [[ "$status" -eq 0 ]]
-    actual_matches_expected "$TEST_DIR"/{,expected_}results.json
+    actual_matches_expected "$TEST_DIR/results.json" "$TEST_DIR/expected_results.json"
 }
 
 @test "missing script" {
@@ -69,7 +69,7 @@ actual_matches_expected() {
     run "$RUN_SCRIPT" "$TEST" "$TEST_DIR" "$TEST_DIR"
 
     [[ "$status" -eq 0 ]]
-    actual_matches_expected "$TEST_DIR"/{,expected_}results.json
+    actual_matches_expected "$TEST_DIR/results.json" "$TEST_DIR/expected_results.json"
 }
 
 @test "missing test" {

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -3,16 +3,28 @@
 RUN_SCRIPT='./bin/run.sh'
 DATA_DIR='tests/data'
 
+actual_matches_expected() {
+    local actual=$1 expected=$2
+
+    # Look at parts of the results instead of just comparing the file contents:
+    # when we upgrade the base image of the test container and the tool
+    # versions change, we won't need to go back and "fix" the expected result
+    # files.
+
+    [[ "$(jq .version "$actual")" == "$(jq .version "$expected")" ]] &&
+    [[ "$(jq .status "$actual")" == "$(jq .status "$expected")" ]] &&
+    [[ "$(jq .tests "$actual")" == "$(jq .tests "$expected")" ]] &&
+    [[ -n "$(jq '."test-environment".bash' "$actual")" ]] &&
+    [[ -n "$(jq '."test-environment".bats' "$actual")" ]]
+}
+
 @test "one passing test" {
     TEST="one_passing"
     TEST_DIR="$DATA_DIR/$TEST"
     run "$RUN_SCRIPT" "$TEST" "$TEST_DIR" "$TEST_DIR"
 
-    RESULTS=$(cat "$TEST_DIR/results.json")
-    EXPECTED_RESULTS=$(cat "$TEST_DIR/expected_results.json")
-
     [[ "$status" -eq 0 ]]
-    [[ "$RESULTS" == "$EXPECTED_RESULTS" ]]
+    actual_matches_expected "$TEST_DIR"/{,expected_}results.json
 }
 
 @test "three passing tests" {
@@ -20,11 +32,8 @@ DATA_DIR='tests/data'
     TEST_DIR="$DATA_DIR/$TEST"
     run "$RUN_SCRIPT" "$TEST" "$TEST_DIR" "$TEST_DIR"
 
-    RESULTS=$(cat "$TEST_DIR/results.json")
-    EXPECTED_RESULTS=$(cat "$TEST_DIR/expected_results.json")
-
     [[ "$status" -eq 0 ]]
-    [[ "$RESULTS" == "$EXPECTED_RESULTS" ]]
+    actual_matches_expected "$TEST_DIR"/{,expected_}results.json
 }
 
 @test "first test fails" {
@@ -32,11 +41,8 @@ DATA_DIR='tests/data'
     TEST_DIR="$DATA_DIR/$TEST"
     run "$RUN_SCRIPT" "$TEST" "$TEST_DIR" "$TEST_DIR"
 
-    RESULTS=$(cat "$TEST_DIR/results.json")
-    EXPECTED_RESULTS=$(cat "$TEST_DIR/expected_results.json")
-
     [[ "$status" -eq 0 ]]
-    [[ "$RESULTS" == "$EXPECTED_RESULTS" ]]
+    actual_matches_expected "$TEST_DIR"/{,expected_}results.json
 }
 
 @test "middle test fails" {
@@ -44,11 +50,8 @@ DATA_DIR='tests/data'
     TEST_DIR="$DATA_DIR/$TEST"
     run "$RUN_SCRIPT" "$TEST" "$TEST_DIR" "$TEST_DIR"
 
-    RESULTS=$(cat "$TEST_DIR/results.json")
-    EXPECTED_RESULTS=$(cat "$TEST_DIR/expected_results.json")
-
     [[ "$status" -eq 0 ]]
-    [[ "$RESULTS" == "$EXPECTED_RESULTS" ]]
+    actual_matches_expected "$TEST_DIR"/{,expected_}results.json
 }
 
 @test "last test fails" {
@@ -56,11 +59,8 @@ DATA_DIR='tests/data'
     TEST_DIR="$DATA_DIR/$TEST"
     run "$RUN_SCRIPT" "$TEST" "$TEST_DIR" "$TEST_DIR"
 
-    RESULTS=$(cat "$TEST_DIR/results.json")
-    EXPECTED_RESULTS=$(cat "$TEST_DIR/expected_results.json")
-
     [[ "$status" -eq 0 ]]
-    [[ "$RESULTS" == "$EXPECTED_RESULTS" ]]
+    actual_matches_expected "$TEST_DIR"/{,expected_}results.json
 }
 
 @test "missing script" {
@@ -68,11 +68,8 @@ DATA_DIR='tests/data'
     TEST_DIR="$DATA_DIR/$TEST"
     run "$RUN_SCRIPT" "$TEST" "$TEST_DIR" "$TEST_DIR"
 
-    RESULTS=$(cat "$TEST_DIR/results.json")
-    EXPECTED_RESULTS=$(cat "$TEST_DIR/expected_results.json")
-
     [[ "$status" -eq 0 ]]
-    [[ "$RESULTS" == "$EXPECTED_RESULTS" ]]
+    actual_matches_expected "$TEST_DIR"/{,expected_}results.json
 }
 
 @test "missing test" {


### PR DESCRIPTION
This adds a "test-environment" key to the `results.json` file produced by the test runner:
```json
{
  "version": 2,
  "status": "fail",
  "test-environment": {
    "bash": "5.0.17(1)-release",
    "bats": "Bats 1.5.0"
  },
  "tests": [
    {
      "name": "say one",
      "status": "fail",
      "test_code": "run bash first_fails.sh one\n[ \"$status\" -eq 0 ]\n[ \"$output\" == \"one\" ]",
      "message": "(in test file this_is_the_test_script.bats, line 6)\n  `[ \"$output\" == \"one\" ]' failed\n"
    },
    {
      "name": "say two",
      "status": "pass",
      "test_code": "run bash first_fails.sh two\n[ \"$status\" -eq 0 ]\n[ \"$output\" == \"two\" ]"
    },
    {
      "name": "say three",
      "status": "pass",
      "test_code": "run bash first_fails.sh three\n[ \"$status\" -eq 0 ]\n[ \"$output\" == \"three\" ]"
    }
  ]
}
```

Exercism currently doesn't do anything with this, but pending exercism/exercism#6096, it might.

Fixes exercism/bash#557