### PR TITLE
A regex checks for a space: the space is optional

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -166,7 +166,7 @@ build_report() {
             local error_message=""
 
             for ((j = i + 1; j < ${#output[@]}; j++)); do
-                if [[ ${output[$j]} =~ ^#\ (.*)$ ]]; then
+                if [[ ${output[$j]} =~ ^#\ ?(.*)$ ]]; then
                     error_message+="${BASH_REMATCH[1]}"$'\n'
                 else
                     break


### PR DESCRIPTION
The current version of bats changed the TAP output a bit: lines starting with a hash may be followed by end-of-line instead of space.