### PR TITLE
Switch the test runner Docker image to use Alpine.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,24 @@
-FROM ubuntu:24.04
+# To refresh, copy the Digest from
+# docker image inspect alpine:3.23.4 | jq -r '.[0].Id'
+FROM alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
-# Ubuntu 24.04 ships with bash version 5.2
-# https://hub.docker.com/layers/library/ubuntu/24.04/images/sha256-3963c438d67a34318a3672faa6debd1dfff48e5d52de54305988b932c61514ca?context=explore
-# 24.04 provides bats v1.10.0
-# Test runner needs jq.
-# Other commands to add to environment, might be used by students
-#   - bc
-#   - GNU awk (Ubuntu 20.04 ships with mawk)
-# Tools commonly used by students that will already be installed include:
-#   - sed, tr, ...
-
-RUN apt-get update                      && \
-    apt-get install -y bats jq bc gawk  && \
-    apt-get purge --auto-remove -y      && \
-    apt-get clean                       && \
-    rm -rf /var/lib/apt/lists/*
+# bats: the test runner framework
+# bash: the language
+# bc:   used for float arithmetic
+# coreutils: provides GNU version of tools like `date`
+# gawk: used for float arithmetic
+# jq:   used for JSON
+RUN apk add --no-cache bats bash bc coreutils gawk jq
 
 COPY . /opt/test-runner
 WORKDIR /opt/test-runner
 ENV BATS_RUN_SKIPPED=true
 ENTRYPOINT ["/opt/test-runner/bin/run.sh"]
+
+# $ docker build --rm -t exercism/bash-test-runner .
+# $ docker run -it --entrypoint bash exercism/bash-test-runner -c 'for i in awk bash bats bc jq; do "$i" --version | head -n1; done'
+# GNU Awk 5.3.2, API 4.0
+# GNU bash, version 5.3.3(1)-release (x86_64-alpine-linux-musl)
+# Bats 1.13.0
+# bc 1.08.2
+# jq-1.8.1

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -69,8 +69,10 @@ run_tests() {
         [[ -f "$test_file" ]] || test_file="${slug//-/_}_test.sh"
     fi
 
-    contents=$( < "$test_file" )
-    sed 's/(load bats-extra)\.bash/$1/' > "$test_file" <<< "$contents"
+    if [[ -e "$test_file" ]]; then
+        contents=$( < "$test_file" )
+        sed 's/(load bats-extra)\.bash/$1/' > "$test_file" <<< "$contents"
+    fi
 
     echo "Test output:"
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -69,7 +69,8 @@ run_tests() {
         [[ -f "$test_file" ]] || test_file="${slug//-/_}_test.sh"
     fi
 
-    perl -i -pe 's/(load bats-extra)\.bash/$1/' "$test_file"
+    contents=$( < "$test_file" )
+    sed 's/(load bats-extra)\.bash/$1/' > "$test_file" <<< "$contents"
 
     echo "Test output:"
 


### PR DESCRIPTION
This shrinks the image from 244MB to 14.6MB.

78MB of the prior image is the Ubuntu layer so we don't actually reclaim that space. However, the Ubuntu `apt-get` command adds 166MB vs the Alpine `apk add` which adds 5.6MB. That saves 160MB.

This passes all the tests and example solutions once https://github.com/exercism/bash/pull/771 and
https://github.com/exercism/bash/pull/772 are included.